### PR TITLE
RUIAN: fix double reuse of existing nodes

### DIFF
--- a/src/org/openstreetmap/josm/plugins/tracer/modules/ruian/RuianModule.java
+++ b/src/org/openstreetmap/josm/plugins/tracer/modules/ruian/RuianModule.java
@@ -518,7 +518,6 @@ public class RuianModule implements TracerModule {
             // Close & create outer way
             outer_nodes.add(outer_nodes.get(0));
             EdWay outer_way = editor.newWay(outer_nodes);
-            outer_way.reuseExistingNodes(reuse_filter);
 
             // Simple way?
             if (!m_record.hasInners())
@@ -552,7 +551,6 @@ public class RuianModule implements TracerModule {
                     throw new AssertionError(tr("Inner way consists of less than 3 nodes"));
                 inner_nodes.add(inner_nodes.get(0));
                 EdWay way = editor.newWay(inner_nodes);
-                way.reuseExistingNodes(reuse_filter);
 
                 multipolygon.addInnerWay(way);
             }


### PR DESCRIPTION
Existing (near) nodes must be reused only once. Second call
leads to duplicate nodes if there's another near node available.
This can easily happen around a junction point of two or more
inaccurate buildings, e.g. series of garages.

This bug was introduced in cf2d6964534bdf1f4db9679dd52738bfecf61d97.
