### PR TITLE
Fix req != full comparison

### DIFF
--- a/servers/ruianBuildings/index.php
+++ b/servers/ruianBuildings/index.php
@@ -100,7 +100,7 @@ if (pg_num_rows($result) > 0)
   }
   $result = pg_query($CONNECT,$query);
 
-  if (pg_num_rows($result) == 1 && !"$req" == "full")
+  if (pg_num_rows($result) == 1 && "$req" != "full")
   {
 
     $geom = pg_result($result,0,"geom");


### PR DESCRIPTION
Operators used for comparison of full request had different
semantics than intended.

Fix by using !=.

I am not a php engineer -- review accordingly!

Fixes #29.